### PR TITLE
Fix format

### DIFF
--- a/filters/includes.py
+++ b/filters/includes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 """
 Process a CodeBlock and, if class is "include", search for the file in the

--- a/filters/includes.py
+++ b/filters/includes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Process a CodeBlock and, if class is "include", search for the file in the

--- a/index.md
+++ b/index.md
@@ -37,7 +37,7 @@ def is_even(num):
     return num % 2 == 0
 ```
 
-### E1101: no-member {#E1101}
+### E1101: No member {#E1101}
 
 This error occurs when you access an object(variable, function...) for a non-exist
 member. To be specific, you should not call a variable or function which is not
@@ -47,7 +47,7 @@ defined.
 ~~~~
 
 
-### E1102: not-callable {#E1102}
+### E1102: Not callable {#E1102}
 
 This error occurs when you call an object which has not been inferred to a
 callable object. In the following example, we should not call x() because x is
@@ -57,7 +57,7 @@ a variable which is not callable.
 ~~~~
 
 
-### E1111: assignment-from-no-return {#E1111}
+### E1111: Assignment from no return {#E1111}
 
 This error occurs when you assign to a function call with the inferred function
 does not return an object. This error is similar to E1128. In the following example,
@@ -67,7 +67,7 @@ f() does not return anything. As a result, x has no value if we assign x f().
 ~~~~
 
 
-### E1120: no-value-for-parameter {#E1120}
+### E1120: No value for parameter {#E1120}
 
 We expect you to pass values for each argument (one for each) in a function.
 In the following example, there should be three values passed to the function
@@ -82,7 +82,7 @@ get_sum(1, 2, 3)
 ```
 
 
-### E1121: too-many-function-args {#E1121}
+### E1121: Too many function args {#E1121}
 
 This error indicates you should pass values for each argument (one for each) in a
 function. It is just the opposite to E1121. In the following example, more
@@ -97,7 +97,7 @@ get_sum(1, 2)
 ```
 
 
-### E1126: invalid-sequence-index {#E1126}
+### E1126: Invalid sequence index {#E1126}
 
 This error occurs when a sequence indexed with an invalid type. For example,
 inside a list, you should always use the index with type integer.
@@ -113,7 +113,7 @@ print(a[0])      # Error on this line
 ```
 
 
-### E1127: invalid-slice-index {#E1127}
+### E1127: Invalid slice index {#E1127}
 
 This error occurs when you use a slice index with wrong types. For example,
 inside a list, whenever you want to get slices of this list, you should use the
@@ -130,7 +130,7 @@ print(a[0:3])
 ```
 
 
-### E1128: assignment-from-none {#E1128}
+### E1128: Assignment from none {#E1128}
 
 This error occurs when an assignment is done on a function call but the inferred
 function returns nothing but None. This error is similar to E1111. In the
@@ -141,7 +141,7 @@ x f().
 ~~~~
 
 
-### E1130: invalid-unary-operand-type {#E1130}
+### E1130: Invalid unary operand type {#E1130}
 
 This error occurs when the unary operand on the objects does not support this
 type of operation. For example, we should never add string to integer.
@@ -150,7 +150,7 @@ type of operation. For example, we should never add string to integer.
 ~~~~
 
 
-### E1131: unsupported-binary-operation {#E1131}
+### E1131: Unsupported binary operation {#E1131}
 
 This error occurs when two operands do not support binary arithmetic operation.
 For example, a dictionary could not be added to a list.
@@ -159,7 +159,7 @@ For example, a dictionary could not be added to a list.
 ~~~~
 
 
-### E1135: unsupported-membership-test {#E1135}
+### E1135: Unsupported membership test {#E1135}
 
 This error occurs when you use an instance in membership test expression which
 implement membership protocol. This error may be similar to E1101.
@@ -170,7 +170,7 @@ object, please make sure the object has this kind of membership.
 ~~~~
 
 
-### E1136: unsubscriptable-object {#E1136}
+### E1136: Unsubscriptable object {#E1136}
 
 This error occurs when you subscript value which does not support subscription.
 In the following example, b[0] could not work on 5.
@@ -179,7 +179,7 @@ In the following example, b[0] could not work on 5.
 ~~~~
 
 
-### E1305: too-many-format-args {#E1305}
+### E1305: Too many format args {#E1305}
 
 This error occurs when you do not use one argument for a {} for format string.
 This error is similar to E1121, meanwhile opposite to E1306.
@@ -199,7 +199,7 @@ s = "{} who is {} lives in {}".format(name, age, country)
 ```
 
 
-### E1306: too-few-format-args {#E1306}
+### E1306: Too few format args {#E1306}
 
 This error occurs when you do not use one argument for a {} for format string.
 This error is similar to E1120, meanwhile opposite to E1305.
@@ -215,7 +215,7 @@ s = "{} and {}".format("first", "second")
 ```
 
 
-### E1310: bad-str-strip-call {#E1310}
+### E1310: Bad str strip call {#E1310}
 
 This error occurs when a constant string contains duplicate characters.
 
@@ -223,7 +223,7 @@ This error occurs when a constant string contains duplicate characters.
 ~~~~
 
 
-### W1303: missing-format-argument-key {#W1303}
+### W1303: Missing format argument key {#W1303}
 
 This error occurs when a format string that uses named fields does not
 receive required keywords. This error is similar to E1120 and E1306. In the
@@ -233,7 +233,7 @@ following example, we should assign three values for bond, james and act.
 ~~~~
 
 
-### W1305: format-combined-specification {#W1305}
+### W1305: Format combined specification {#W1305}
 
 This error occurs when a format string contains both automatic field numbering
 (e.g. ‘{}’) and manual field specification (e.g. ‘{0}’).
@@ -254,7 +254,7 @@ s = "{0} and {1}".format("a", "b")
 ```
 
 
-### W1401: anomalous-backslash-in-string {#W1401}
+### W1401: Anomalous backslash in string {#W1401}
 
 This error occurs when a backslash is in a literal string but not as an escape.
 
@@ -510,7 +510,7 @@ Note: the limit is 50 statements.
 This is some helpful description of the C0111 error.
 
 
-### C0102 Blacklisted name {#C0102}
+### C0102: Blacklisted name {#C0102}
 
 This error occurs when a variable name is listed in the black list. The black 
 list includes names:
@@ -528,7 +528,7 @@ Students are expected to use meaningful variable names.
 ~~~~
 
 
-### C0103 Invalid Name {#C0103}
+### C0103: Invalid Name {#C0103}
 
 This error occurs when a name does not follow the format associated with to its type (constant, variable ...). 
 
@@ -544,7 +544,7 @@ A special character accepted in all types of names is '_'.
 ~~~~
 
 
-### C0111 Missing Docstring {#C0111}
+### C0111: Missing Docstring {#C0111}
 
 This error occurs when a module, function, class or method has no docstring. 
 Some special methods like __init__ don't require a docstring. Students are 
@@ -554,7 +554,7 @@ expected to write docstrings for every module, function, class and method.
 ~~~~
 
 
-### C0112 Empty Docstring {#C0112}
+### C0112: Empty Docstring {#C0112}
 
 This error occurs when a module, function, class or method has an empty 
 docstring like,
@@ -571,7 +571,7 @@ function, class and method.
 ~~~~
 
 
-### C0113 Unneeded not {#C0113}
+### C0113: Unneeded not {#C0113}
 
 This error occurs when a boolean expression contains an unneeded negation. If 
 you are getting this error, the expression can be simplified to not use a 
@@ -595,7 +595,7 @@ def is_true():
 ```
 
 
-### C0121 Singleton comparison {#C0121}
+### C0121: Singleton comparison {#C0121}
 
 This is an error that occurs when an expression is compared to singleton values 
 like True, False or None.
@@ -618,7 +618,7 @@ def is_true():
 ```
 
 
-### C0123 Unidiomatic type check {#C0123}
+### C0123: Unidiomatic type check {#C0123}
 
 This error occurs when type() is used instead of isinstance() for a type check. 
 Students are expected to use `isinstance(x, Y)` instead of `type(x) == Y`.
@@ -639,7 +639,7 @@ def is_int(obj):
 ```
 
 
-### E0101 Return in init {#E0101}
+### E0101: Return in init {#E0101}
 
 This error occurs when a return statement is used in the __init__ method. 
 Students should not use a return statement in the  __init__ method as it is not 
@@ -650,7 +650,7 @@ initializes objects at runtime.
 ~~~~
 
 
-### E0102 Function redefined {#E0102}
+### E0102: Function redefined {#E0102}
 
 This error occurs when a function, class or method is redefined. If you are 
 getting this error, you should make sure all the functions, methods and classes 
@@ -660,7 +660,7 @@ you define have different names.
 ~~~~
 
 
-### E0103 Not in loop {#E0103}
+### E0103: Not in loop {#E0103}
 
 This error occurs when `break` and `continue` keywords are used outside loops. 
 The keyword `break` is used to exit a loop early and the keyword `continue` is 
@@ -671,7 +671,7 @@ loops.
 ~~~~
 
 
-### E0104 Return outside function {#E0104}
+### E0104: Return outside function {#E0104}
 
 This error occurs when a `return` statement is found outside a function or 
 method. If you are getting this error, please check the indentation levels in 
@@ -681,7 +681,7 @@ your code carefully.
 ~~~~
 
 
-### E0108 Duplicate argument name {#E0108}
+### E0108: Duplicate argument name {#E0108}
 
 This error occurs if there are duplicate argument names in function 
 definitions. If you are getting this error, please make sure all the arguments 
@@ -691,7 +691,7 @@ have distinct names.
 ~~~~
 
 
-### W0101 Unreachable {#W0101}
+### W0101: Unreachable {#W0101}
 
 This error occurs when there is some code behind a `return` or `raise` 
 statement. This code will never be run.
@@ -700,7 +700,7 @@ statement. This code will never be run.
 ~~~~
 
 
-### W0102 Dangerous default value {#W0102}
+### W0102: Dangerous default value {#W0102}
 
 This error occurs when a mutable value such as a list or dictionary is given a 
 default value in the function or method definition. It is dangerous to give 
@@ -730,7 +730,7 @@ If you want to avoid this situation then, you should use `None` as a default
 value. Students should be careful when assigning a default value to mutable 
 objects.
 
-### W0104 Pointless statement {#W0104}
+### W0104: Pointless statement {#W0104}
 
 This error occurs when a statement doesn't have any effect. This means that 
 when the code for a statement is run, nothing is executed. This may not be what was 
@@ -740,7 +740,7 @@ intended.
 ~~~~
 
 
-### W0107 Unnecessary pass {#W0107}
+### W0107: Unnecessary pass {#W0107}
 
 This error occurs when a `pass` statement is used that can be avoided (or has 
 no effect). If you are able to remove the `pass` statement without changing the 
@@ -753,7 +753,7 @@ In the above example, the `pass` statement is "unnecessary" as the program's
 effect is not changed if `pass` is removed.
 
 
-### W0109 Duplicate key {#W0109}
+### W0109: Duplicate key {#W0109}
 
 This error occurs when a dictionary expression binds the same key multiple 
 times.
@@ -762,7 +762,7 @@ times.
 ~~~~
 
 
-### W0125 Using constant test {#W0125}
+### W0125: Using constant test {#W0125}
 
 This error occurs when a conditional statement like an `if` statement uses a 
 constant value for its test. This is bad as the conditional statements using a 
@@ -773,7 +773,7 @@ statement should not be used.
 ~~~~
 
 
-### W0199 Assert on tuple {#W0199}
+### W0199: Assert on tuple {#W0199}
 
 This error occurs when an "assert" statement is called like `assert (x, y)`. 
 `assert` acting on a tuple always returns true if the tuple is non-empty, and 


### PR DESCRIPTION
Fixed missing semi-colons and different title formats for messages in the website documentation #30 .
