### PR TITLE
Fix background not full width on narrow view

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -76,6 +76,7 @@ pre code {
   white-space: pre;
   display: block;
   margin: 20px;
+  overflow: scroll;
 }
 
 form input, form textarea {


### PR DESCRIPTION
Fixes background width issue on `<pre>` elements:

![background width issue](https://cloud.githubusercontent.com/assets/4323647/16281874/42e271d2-3894-11e6-8c35-a24dca7fb133.png)
