### PR TITLE
Fix Build when dir already exists in gen

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,7 +1,7 @@
 import subprocess
 import os
 import sys
-from shutil import copytree
+from distutils.dir_util import copy_tree
 
 if os.path.isfile('gen'):
     sys.exit('Error: "gen" already exists as a regular file')
@@ -20,7 +20,9 @@ completed_process = subprocess.run([
     'filters/includes.py'
 ], stdout=subprocess.PIPE)
 
-copytree('styles', 'gen/styles')
+copy_tree('images', 'gen/images')  # overwrite existing location with copy_tree.
+copy_tree('styles', 'gen/styles')
+copy_tree('scripts', 'gen/scripts')
 
 if not completed_process.returncode:
-    print("Successfully Built File: index.html")
+    print('Successful Build.')

--- a/build.py
+++ b/build.py
@@ -22,7 +22,6 @@ completed_process = subprocess.run([
 
 copy_tree('images', 'gen/images')  # overwrite existing location with copy_tree.
 copy_tree('styles', 'gen/styles')
-copy_tree('scripts', 'gen/scripts')
 
 if not completed_process.returncode:
-    print('Successful Build.')
+    print('Successful Build. Open gen/index.html to see the website.')


### PR DESCRIPTION
changed `copytree` to `copy_tree` since the former would fail if the dir exists in `/gen/`. Also added the missing `images` dir, and our new `scripts` dir.
