### PR TITLE
add most common troubleshooting message to build failure

### DIFF
--- a/build.py
+++ b/build.py
@@ -28,3 +28,5 @@ copy_tree('styles', 'gen/styles')
 
 if not completed_process.returncode:
     print('Successful Build. Open gen/index.html to see the website.')
+elif sys.platform == 'darwin':
+    print('Did you set /usr/bin/env python3 in includes.py?')


### PR DESCRIPTION
The most common error on Mac is having `#!/usr/bin/env python` instead of `#!/usr/bin/env python3`. It's mentioned in the readme under troubleshooting, but should be mentioned in the terminal output for better usability.
